### PR TITLE
fix: deprecated ruby action

### DIFF
--- a/.github/workflows/schedule.yml
+++ b/.github/workflows/schedule.yml
@@ -17,9 +17,9 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: Set up Ruby 2.6
-        uses: actions/setup-ruby@v1
+        uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.6.x
+          ruby-version: 2.6
       - name: Render latest template
         run: |
           ruby render.rb | tee snyk.json


### PR DESCRIPTION
Using the Ruby action maintained by Ruby devs instead of the deprecated one by GH