### PR TITLE
cli-422: update cli download url and add utm parameter

### DIFF
--- a/render.rb
+++ b/render.rb
@@ -12,7 +12,7 @@ require "open-uri"
 # Return the URL, SHA and version information for the latest release
 def get_latest_release()
   bin = "snyk-win.exe"
-  snyk_cli_version_url = "https://static.snyk.io/cli/latest/release.json"
+  snyk_cli_version_url = "https://downloads.snyk.io/cli/latest/release.json"
   data = URI.parse(snyk_cli_version_url).read
   obj = JSON.parse(data)
   version = obj["version"]

--- a/render.rb
+++ b/render.rb
@@ -17,9 +17,16 @@ def get_latest_release()
   obj = JSON.parse(data)
   version = obj["version"]
   url = obj["assets"][bin]["url"]
+
+  # Parse the URL and add the utm parameter
+  uri = URI.parse(url)
+  new_query_ar = URI.decode_www_form(uri.query || '') << ["utm_source", "SCOOP"]
+  uri.query = URI.encode_www_form(new_query_ar)
+  url_with_utm = uri.to_s
+
   sha256 = obj["assets"][bin]["sha256"].split.first
 
-  return url, sha256, version
+  return url_with_utm, sha256, version
 end
 
 @url, @sha256, @version = get_latest_release()


### PR DESCRIPTION
How to test output:

`ruby render.rb | jq`

```json
{
  "version": "1.1292.2",
  "url": "https://static.snyk.io/cli/v1.1292.2/snyk-win.exe?utm_source=SCOOP",
  "bin": [
    [
      "snyk-win.exe",
      "snyk"
    ]
  ],
  "hash": "9789c9ca5e68d7ef8ca18377b90882e344db85cf885bf8a8c2b27c60a529cb8c",
  "homepage": "https://github.com/snyk/snyk",
  "description": "Find & fix known vulnerabilities in open-source dependencies",
  "license": "Apache-2.0"
}
```